### PR TITLE
feat!: allow use typescript eslint for js & fix markdown ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,30 @@
       "require": "./dist/base.js",
       "import": "./dist/base.mjs"
     },
+    "./disable-type-aware": {
+      "types": "./dist/disable-type-aware.d.ts",
+      "require": "./dist/disable-type-aware.js",
+      "import": "./dist/disable-type-aware.mjs"
+    },
     "./import": {
       "types": "./dist/import.d.ts",
       "require": "./dist/import.js",
       "import": "./dist/import.mjs"
     },
+    "./md": {
+      "types": "./dist/md.d.ts",
+      "require": "./dist/md.js",
+      "import": "./dist/md.mjs"
+    },
     "./react": {
       "types": "./dist/react.d.ts",
       "require": "./dist/react.js",
       "import": "./dist/react.mjs"
+    },
+    "./ts-for-js": {
+      "types": "./dist/ts-for-js.d.ts",
+      "require": "./dist/ts-for-js.js",
+      "import": "./dist/ts-for-js.mjs"
     },
     "./ts": {
       "types": "./dist/ts.d.ts",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,8 +1,8 @@
-import { newlineBlocks } from './rules/newline-blocks'
+import { newlineBlocks } from './rules'
 import { defineConfig } from './utils'
 
 export default defineConfig({
-  extends: ['prettier', 'plugin:markdown/recommended'],
+  extends: ['prettier'],
 
   parserOptions: {
     ecmaFeatures: { jsx: true },

--- a/src/disable-type-aware.ts
+++ b/src/disable-type-aware.ts
@@ -1,0 +1,7 @@
+import { defineConfig, disableTypeAwareRules, require } from './utils'
+
+export default defineConfig({
+  extends: [require.resolve('./ts-for-js')],
+  parserOptions: { project: null },
+  rules: disableTypeAwareRules(),
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     isTs && './ts',
     './unicorn',
     isVue && './vue',
+    './md',
   ]
     .filter(Boolean)
     .map((path) => require.resolve(path as string)),

--- a/src/md.ts
+++ b/src/md.ts
@@ -1,0 +1,12 @@
+import { defineConfig, getTsFiles, require } from './utils'
+
+export default defineConfig({
+  extends: ['plugin:markdown/recommended'],
+
+  overrides: [
+    {
+      extends: [require.resolve('./disable-type-aware')],
+      files: getTsFiles('**/*.md'),
+    },
+  ],
+})

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,1 @@
+export * from './newline-blocks'

--- a/src/ts-for-js.ts
+++ b/src/ts-for-js.ts
@@ -1,0 +1,61 @@
+import { newlineBlocks } from './rules'
+import { defineConfig, env } from './utils'
+
+const { tsconfig } = env
+
+export default defineConfig({
+  extends: ['plugin:typescript-sort-keys/recommended'],
+
+  parser: '@typescript-eslint/parser',
+
+  parserOptions: {
+    project: tsconfig,
+    tsconfigRootDir: process.cwd(),
+  },
+
+  plugins: ['@typescript-eslint'],
+
+  rules: {
+    '@typescript-eslint/array-type': 'warn',
+    '@typescript-eslint/consistent-type-definitions': 'warn',
+    '@typescript-eslint/consistent-type-exports': 'warn',
+
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      {
+        disallowTypeAnnotations: false,
+        fixStyle: 'inline-type-imports',
+      },
+    ],
+
+    '@typescript-eslint/lines-between-class-members': 'warn',
+    '@typescript-eslint/method-signature-style': ['warn', 'method'],
+    // '@typescript-eslint/no-implicit-any-catch': 'warn',
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
+    // '@typescript-eslint/no-unnecessary-condition': 'warn',
+    '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+
+    '@typescript-eslint/padding-line-between-statements': [
+      'warn',
+      ...newlineBlocks,
+      {
+        blankLine: 'always',
+        next: ['interface', 'type', 'export'],
+        prev: '*',
+      },
+    ],
+
+    '@typescript-eslint/prefer-as-const': 'warn',
+    '@typescript-eslint/prefer-for-of': 'warn',
+    '@typescript-eslint/prefer-includes': 'warn',
+    // '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+    '@typescript-eslint/prefer-optional-chain': 'warn',
+    '@typescript-eslint/prefer-ts-expect-error': 'warn',
+    '@typescript-eslint/return-await': 'warn',
+
+    // Rules of Conflicts
+    'lines-between-class-members': 'off',
+    'no-return-await': 'off',
+    'padding-line-between-statements': 'off',
+  },
+})

--- a/src/ts.ts
+++ b/src/ts.ts
@@ -1,72 +1,23 @@
-import fs from 'node:fs'
-import path from 'node:path'
-import { newlineBlocks } from './rules/newline-blocks'
-import { defineConfig } from './utils'
+import { defineConfig, env, getTsFiles, require } from './utils'
 
-const tsconfig = process.env.ESLINT_TSCONFIG || 'tsconfig.json'
-const tsconfigPath = path.resolve(process.cwd(), tsconfig)
-const hasTsconfig = fs.existsSync(tsconfigPath)
+const { hasTsconfig, useTsForJs } = env
 
 export default defineConfig({
-  extends: ['plugin:typescript-sort-keys/recommended'],
-
   overrides: hasTsconfig
     ? [
         {
-          files: ['**/*.{ts,tsx}'],
-          parser: '@typescript-eslint/parser',
-
-          parserOptions: {
-            project: tsconfig,
-            tsconfigRootDir: process.cwd(),
-          },
-
-          plugins: ['@typescript-eslint'],
-
-          rules: {
-            '@typescript-eslint/array-type': 'warn',
-            '@typescript-eslint/consistent-type-definitions': 'warn',
-            '@typescript-eslint/consistent-type-exports': 'warn',
-
-            '@typescript-eslint/consistent-type-imports': [
-              'warn',
-              {
-                disallowTypeAnnotations: false,
-                fixStyle: 'inline-type-imports',
-              },
-            ],
-
-            '@typescript-eslint/lines-between-class-members': 'warn',
-            '@typescript-eslint/method-signature-style': ['warn', 'method'],
-            // '@typescript-eslint/no-implicit-any-catch': 'warn',
-            '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
-            // '@typescript-eslint/no-unnecessary-condition': 'warn',
-            '@typescript-eslint/no-unnecessary-qualifier': 'warn',
-
-            '@typescript-eslint/padding-line-between-statements': [
-              'warn',
-              ...newlineBlocks,
-              {
-                blankLine: 'always',
-                next: ['interface', 'type', 'export'],
-                prev: '*',
-              },
-            ],
-
-            '@typescript-eslint/prefer-as-const': 'warn',
-            '@typescript-eslint/prefer-for-of': 'warn',
-            '@typescript-eslint/prefer-includes': 'warn',
-            // '@typescript-eslint/prefer-nullish-coalescing': 'warn',
-            '@typescript-eslint/prefer-optional-chain': 'warn',
-            '@typescript-eslint/prefer-ts-expect-error': 'warn',
-            '@typescript-eslint/return-await': 'warn',
-
-            // Rules of Conflicts
-            'lines-between-class-members': 'off',
-            'no-return-await': 'off',
-            'padding-line-between-statements': 'off',
-          },
+          extends: [require.resolve('./ts-for-js')],
+          files: getTsFiles(),
         },
+
+        ...(useTsForJs
+          ? [
+              {
+                extends: [require.resolve('./disable-type-aware')],
+                files: ['.eslintrc.cjs'],
+              },
+            ]
+          : []),
       ]
     : [],
 })

--- a/src/utils/disable-type-aware-rules.ts
+++ b/src/utils/disable-type-aware-rules.ts
@@ -1,0 +1,10 @@
+import { rules } from '@typescript-eslint/eslint-plugin'
+
+/** @see https://github.com/eslint/eslint-plugin-markdown/issues/209 */
+export const disableTypeAwareRules = () => {
+  return Object.fromEntries(
+    Object.entries(rules)
+      .filter(([, rule]) => rule.meta.docs?.requiresTypeChecking)
+      .map(([name]) => [`@typescript-eslint/${name}`, 'off'] as const)
+  )
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,12 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { isPackageExists } from 'local-pkg'
 
 export const env = {
+  get hasTsconfig() {
+    return fs.existsSync(env.tsconfigPath)
+  },
+
   get isReact() {
     return isPackageExists('react')
   },
@@ -11,5 +17,17 @@ export const env = {
 
   get isVue() {
     return isPackageExists('vue')
+  },
+
+  get tsconfig() {
+    return process.env.ESLINT_TSCONFIG || 'tsconfig.json'
+  },
+
+  get tsconfigPath() {
+    return path.resolve(process.cwd(), env.tsconfig)
+  },
+
+  get useTsForJs() {
+    return process.env.USE_TS_FOR_JS === 'true'
   },
 }

--- a/src/utils/get-ts-files.ts
+++ b/src/utils/get-ts-files.ts
@@ -1,0 +1,11 @@
+import { env } from './env'
+
+export const getTsFiles = (glob = '**') => {
+  const { useTsForJs } = env
+
+  return [
+    //
+    `${glob}/*.{ts,tsx}`,
+    useTsForJs && `${glob}/*.{js,jsx,cjs,mjs}`,
+  ].filter(Boolean) as string[]
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
 export * from './define-config'
+export * from './disable-type-aware-rules'
 export * from './env'
+export * from './get-ts-files'
 export * from './require'


### PR DESCRIPTION
## Features

- Now, you can set `process.env.USE_TS_FOR_JS = 'true'` in `.eslintrc.cjs` to enable typescript eslint for `.js` files
- Separate the `markdown` configuration file and fix the `ts` errors in `.md` files (disable type-aware rules).
- Export `@u3u/eslint-config/disable-type-aware` for easy customization of disabling.